### PR TITLE
pyicbinn: Link with -Bsymbolic

### DIFF
--- a/pyicbinn/setup.py
+++ b/pyicbinn/setup.py
@@ -38,6 +38,7 @@ ext_modules = [Extension("_pyicbinn",
 			sources=['pyicbinn_wrap.c'],
 			library_dirs=libicbinn_lib_dirs,
 			libraries=libicbinn_libs,
+			extra_link_args=["-Wl,-Bsymbolic"],
 			include_dirs=libicbinn_include_dirs + [ '.' ])]
 
 setup(name = 'pyicbinn',   version = '0.1',


### PR DESCRIPTION
The sync-client is failing to connect to dom0 icbinn server.  Tracing
through the code, we see a failure in a serialization call inside
xdr_callhdr.  Strangely, it is reported as inside the glibc rpc code
instead of libtirpc.

Turns out xdr_callhdr and other functions are called through plt
entries, and the glibc implementation is found and used.  If we
LD_PRELOAD libtirpc, we succeed in using that implementation.

sync-client calls into this code through pyicbinn.py and _pyicbinn.so.
_pyicbinn.so is weird since it contains copies of the libtirpc code
through its inclusion of libicbinn-resolved, yet calls go through the
plt.

The linker has the the -Bsymbolic flag:
"When creating a shared library, bind references to global symbols to
the definition within the shared library, if any."

Link with -Bsymbolic to avoid the plt entries and just directly call the
libtirpc code inside _pyicbinn.so.

glibc 2.26 drops its own RPC code.  This patch should be reverted when we
move to a newer glibc.

OXT-1628

Signed-off-by: Jason Andryuk <jandryuk@gmail.com>