### PR TITLE
pyicbinn: link against libicbinn not libicbinn_resolved

### DIFF
--- a/pyicbinn/setup.py
+++ b/pyicbinn/setup.py
@@ -28,9 +28,9 @@ def fish(x):
 def check_output(a):
 	return subprocess.Popen(a, stdout=subprocess.PIPE).communicate()[0]
 
-libicbinn_include_dirs = fish(check_output(["pkg-config", "--cflags-only-I", "libicbinn_resolved"]))
-libicbinn_lib_dirs = fish(check_output(["pkg-config", "--libs-only-L", "libicbinn_resolved"]))
-libicbinn_libs = fish(check_output(["pkg-config", "--libs-only-l", "libicbinn_resolved"]))
+libicbinn_include_dirs = fish(check_output(["pkg-config", "--cflags-only-I", "libicbinn"]))
+libicbinn_lib_dirs = fish(check_output(["pkg-config", "--libs-only-L", "libicbinn"]))
+libicbinn_libs = fish(check_output(["pkg-config", "--libs-only-l", "libicbinn"]))
 
 subprocess.call(["swig","-python","pyicbinn.i"])
 
@@ -38,7 +38,6 @@ ext_modules = [Extension("_pyicbinn",
 			sources=['pyicbinn_wrap.c'],
 			library_dirs=libicbinn_lib_dirs,
 			libraries=libicbinn_libs,
-			extra_link_args=["-Wl,-Bsymbolic"],
 			include_dirs=libicbinn_include_dirs + [ '.' ])]
 
 setup(name = 'pyicbinn',   version = '0.1',


### PR DESCRIPTION
libicbinn_resolved is a static library, so security_flags specifying
-fPIC causes a link error.  libicbinn_resolved is a weird wrapping of
libicbinn.  python has shared library support, so we can just use that
to link against libicbinn itself.

While switching to libicbinn, we drop -Bsymbolic linking which was
introduced in 270cc8c30344 "pyicbinn: Link with -Bsymbolic".  libicbinn
use versioned symbols such as xdr_enum@@TIRPC_0.3.0, so we won't
re-introduce the problem of calling a mixture of the glibc and tirpc
code.

OXT-1697
OXT-447

Signed-off-by: Jason Andryuk <jandryuk@gmail.com>

This goes along with https://github.com/OpenXT/xenclient-oe/pull/1297

@rneilturner this seems okay in my limited testing, but I don't have access to a full end-to-end sync setup.  Would you be able to test?