### PR TITLE
gitignore: create/update them

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,5 @@
-/libicbinn/configure
+# OE
+oe-logs
+oe-workdir
+*~
+tags

--- a/libicbinn/.gitignore
+++ b/libicbinn/.gitignore
@@ -1,41 +1,88 @@
-*.lo
-*.o
-config.h
+# http://www.gnu.org/software/automake
+
+Makefile.in
+/ar-lib
+/mdate-sh
+/py-compile
+/test-driver
+/ylwrap
+.deps/
+.dirstamp
+
+# http://www.gnu.org/software/autoconf
+
+autom4te.cache
+/autoscan.log
+/autoscan-*.log
+/aclocal.m4
+/compile
+/config.guess
+/config.h.in
+/config.log
+/config.status
+/config.sub
+/configure
+/configure.scan
+/depcomp
+/install-sh
+/missing
+stamp-h1
+
+# https://www.gnu.org/software/libtool/
+
+/ltmain.sh
+
+# http://www.gnu.org/software/texinfo
+
+/texinfo.tex
+
+# http://www.gnu.org/software/m4/
+
+m4/libtool.m4
+m4/ltoptions.m4
+m4/ltsugar.m4
+m4/ltversion.m4
+m4/lt~obsolete.m4
+*-libtool
+
+# Generated Makefile
+# (meta build system like autotools,
+# can automatically generate from config.status script
+# (which is called by configure script))
 Makefile
-version.h
-version.sed
-*.swp
-icbinn-head.h
-icbinn.h
+
+# C
+*.d
+*.o
+
+# Libraries
 *.a
 *.la
-rpc/*.h
-missing
-Makefile.in
-install-sh
-libicbinn-config
+*.lo
+
+# Shared objects (inc. Windows DLLs)
+*.so
+*.so.*
+
+# Executables
+*.out
+
+# Artefacts
+.libs/
+teststore
 libicbinn-config.src
-libicbinn.pc
+libicbinn-config
 libicbinn.pc.src
-libtool
-ltmain.sh
-stamp-h1
-compile
-config.guess
-config.h.in
-config.log
-config.status
-config.sub
-depcomp
-aclocal.m4
-.deps
-.libs
-autom4te.cache
-rpc/icbinn_prot_clnt.c
-rpc/icbinn_prot_svc.c
-rpc/icbinn_prot_xdr.c
-client/icbinn_ftp
+libicbinn.pc
+config.h*
+icbinn_prot*.[ch]
 server/icbinn_svc
+src/icbinn-head.h
+src/icbinn.h
+server/xenmgr_client.h
+server/xenmgr_vm_client.h
 test/test
+version.h
+version.sed
 INSTALL
-*-libtool
+client/icbinn_ftp

--- a/pyicbinn/.gitignore
+++ b/pyicbinn/.gitignore
@@ -3,3 +3,5 @@ pyicbinn.py
 pyicbinn.pyc
 _pyicbinn.so
 pyicbinn_wrap.c
+lib.*/
+temp.*/


### PR DESCRIPTION
externalsrc depends on a revision created with git add -A (https://github.com/openembedded/openembedded-core/blob/dunfell/meta/classes/externalsrc.bbclass#L204). Up to date gitignore would prevent unecessary rebuilds.

Based on templates from https://github.com/github/gitignore.